### PR TITLE
replaced write-information to write-verbose and add new record on histogram for instance with more than 500 Dbs.

### DIFF
--- a/DBSizingQueries/CollectSQLProfile.ps1
+++ b/DBSizingQueries/CollectSQLProfile.ps1
@@ -38,7 +38,7 @@ PROCESS
             if($Anonymize){$sql = $sql.Replace("@@SERVERNAME","'$serverid'")}
             $OutFile = Join-Path -Path $OutPath -ChildPath $q.filename
 
-            Write-Information "Collecting data from $i"
+            Write-Verbose "Collecting data from $i"
             if($SqlUser -and $SqlPassword)
             {
                 $output = Invoke-SqlCmd -ServerInstance "$i" -Database TempDB -Query "$sql" -Username $SqlUser -Password $SqlPassword

--- a/DBSizingQueries/Parse-RubrikSizing.ps1
+++ b/DBSizingQueries/Parse-RubrikSizing.ps1
@@ -37,6 +37,11 @@ $return = [ordered]@{
             
         }
 
+$MaxDbCountSingleHost = ($rawdata | Group-Object ServerName | Sort-Object Count -Descending| Select-Object Name, Count -first 1)
+if($MaxDbCountSingleHost.Count -gt 500){
+    $return.Add("Max DB count for a single host [$($MaxDbCountSingleHost.Name)]",$($MaxDbCountSingleHost.Count))
+}
+
 $BinStart = 0
 foreach($bin in $HistogramBins){
     $BinCount = ($rawdata | Where-Object {[int]$_.DBTotalSizeMB/1024 -gt $BinStart -and [int]$_.DBTotalSizeMB/1024 -le $bin} | Measure-Object).Count


### PR DESCRIPTION
- I changed the command write-information to write-verbose, write-information is a PowerShell 5.0+ command, I had a customer that was not allowed to upgrade his PowerShell.
- Also added a new record on histogram report to consider a host with more than 500 DBs per instance