### PR TITLE
Add files via upload

### DIFF
--- a/SPBMtoSLAv3.ps1
+++ b/SPBMtoSLAv3.ps1
@@ -1,0 +1,33 @@
+﻿# This script builds on the previous Storage Policy to SLA Protection by allowing you the user to select what Storage Policy to associate with a SLA.
+# Instead of needing to know what SLAs and Storage Policies are in your environment, it will query the vCenter and Rubrik machine for you. 
+# In addition to this, I added the capability to capture two different credentials and allowed you to specify the vCenter and Rubrik brik name realtime.
+# This script will continue to grow as I think up of new capabilities to add to it. At the end the script gives you a short summary of what VMs are 
+# still unprotected. 
+#
+#
+
+[System.Reflection.Assembly]::LoadWithPartialName('Microsoft.VisualBasic') | Out-Null
+
+$vcenter = [Microsoft.VisualBasic.Interaction]::InputBox("Please enter your vCenter Server name", "vCenter Prompt")
+$vcreds=Get-Credential -Message "Please enter your vCenter Credentials"
+
+$brik = [Microsoft.VisualBasic.Interaction]::InputBox("Please enter your Rubrik brik name or IP", "Rubrik Brik Prompt")
+$rcreds=Get-Credential -Message "Please enter your Rubrik Credentials"
+
+$null = VMware.VimAutomation.Core\Connect-VIServer -Server $vcenter -Credential $vcreds
+$null = Connect-Rubrik -Server $brik -Credential $rcreds
+
+
+get-rubriksla | select-object name,id | out-gridview -PassThru -Title 'Please select an awesome SLA to assign to your VM' | 
+foreach-object {
+    $Sla = $_
+    Get-SpbmStoragePolicy | Select-Object -Property Name | out-gridview -Title 'Select Storage Policy to assign "$($sla.name)" to...' -PassThru | 
+    ForEach-Object {
+        Get-SpbmStoragePolicy -Name $_.Name | Get-SpbmEntityConfiguration -VMsOnly | 
+            ForEach-Object {
+            $Null = Get-RubrikVM -Name $_.Name | Protect-RubrikVM -SLAID $Sla.Id -Confirm:$false
+        }
+    }
+}
+Write-Output "These VMs are still unprotected and have no SLA assigned"
+Get-RubrikVM -SLAAssignment Unassigned | Format-Table Name

--- a/SPBMtoSLAv3.ps1
+++ b/SPBMtoSLAv3.ps1
@@ -1,21 +1,21 @@
-﻿# This script builds on the previous Storage Policy to SLA Protection by allowing you the user to select what Storage Policy to associate with a SLA.
-# Instead of needing to know what SLAs and Storage Policies are in your environment, it will query the vCenter and Rubrik machine for you. 
-# In addition to this, I added the capability to capture two different credentials and allowed you to specify the vCenter and Rubrik brik name realtime.
-# This script will continue to grow as I think up of new capabilities to add to it. At the end the script gives you a short summary of what VMs are 
-# still unprotected. 
-#
-#
+﻿<#
+This script builds on the previous Storage Policy to SLA Protection by allowing you the user to select what Storage Policy to associate with a SLA.
+Instead of needing to know what SLAs and Storage Policies are in your environment, it will query the vCenter and Rubrik machine for you. 
+In addition to this, I added the capability to capture two different credentials and allowed you to specify the vCenter and Rubrik cluster name realtime.
+This script will continue to grow as I think up of new capabilities to add to it. At the end the script gives you a short summary of what VMs are 
+still unprotected. 
+#>
 
 [System.Reflection.Assembly]::LoadWithPartialName('Microsoft.VisualBasic') | Out-Null
 
 $vcenter = [Microsoft.VisualBasic.Interaction]::InputBox("Please enter your vCenter Server name", "vCenter Prompt")
 $vcreds=Get-Credential -Message "Please enter your vCenter Credentials"
 
-$brik = [Microsoft.VisualBasic.Interaction]::InputBox("Please enter your Rubrik brik name or IP", "Rubrik Brik Prompt")
+$rubrikcluster = [Microsoft.VisualBasic.Interaction]::InputBox("Please enter your Rubrik cluster name or IP", "Rubrik Cluster Prompt")
 $rcreds=Get-Credential -Message "Please enter your Rubrik Credentials"
 
 $null = VMware.VimAutomation.Core\Connect-VIServer -Server $vcenter -Credential $vcreds
-$null = Connect-Rubrik -Server $brik -Credential $rcreds
+$null = Connect-Rubrik -Server $rubrikcluster -Credential $rcreds
 
 
 get-rubriksla | select-object name,id | out-gridview -PassThru -Title 'Please select an awesome SLA to assign to your VM' | 


### PR DESCRIPTION
This script builds on the previous Storage Policy to SLA Protection by allowing you the user to select what Storage Policy to associate with a SLA. Instead of needing to know what SLAs and Storage Policies are in your environment, it will query the vCenter and Rubrik machine for you.  In addition to this, I added the capability to capture two different credentials and allowed you to specify the vCenter and Rubrik brik name realtime. This script will continue to grow as I think up of new capabilities to add to it. At the end the script gives you a short summary of what VMs are still unprotected.

# Description

Please describe your pull request in detail.

## Related Issue

This project only accepts pull requests related to open issues.

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

_Please link to the issue here_

## Motivation and Context

Why is this change required? What problem does it solve?

## How Has This Been Tested?

Tested against local lab

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
