### PR TITLE
Remove defaults from instances

### DIFF
--- a/MSSQL/Start-RubrikDBMigration.ps1
+++ b/MSSQL/Start-RubrikDBMigration.ps1
@@ -70,7 +70,7 @@ param(
     [String]$SourceSQLHost,
     
     [Parameter(ParameterSetName="CMDLINE")]
-    [String]$SourceSQLInstance = 'MSSQLSERVER',
+    [String]$SourceSQLInstance,
 
     [Parameter(ParameterSetName="CMDLINE")]
     [String[]]$Databases,
@@ -79,7 +79,7 @@ param(
     [String]$TargetSQLHost,
 
     [Parameter(ParameterSetName="CMDLINE")]
-    [String]$TargetSQLInstance = 'MSSQLSERVER',
+    [String]$TargetSQLInstance,
     
     [Parameter(ParameterSetName="CMDLINE")]
     [String]$TargetDataPath,


### PR DESCRIPTION
Default values are causing the check for null later on to not behave as expected.

# Description

Remove the default values. SQLCMD queries fail with them in place if values are not supplied.

## Related Issue

This project only accepts pull requests related to open issues.

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

_Please link to the issue here_

## Motivation and Context

Why is this change required? What problem does it solve?

## How Has This Been Tested?

* Please describe in detail how you tested your changes.
* Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **[CONTRIBUTION](/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
