### PR TITLE
Added sizing fix for very large databases.

### DIFF
--- a/DBSizingQueries/RubrikSQLProfile-DBInfo.sql
+++ b/DBSizingQueries/RubrikSQLProfile-DBInfo.sql
@@ -76,7 +76,7 @@ AS
 (
 	select 
 		db.name
-		, sum(mf.size * 8 /1024) DBTotalSizeMB
+		,convert(bigint,sum(mf.size/128.0)) DBTotalSizeMB
 
 	FROM sys.databases db
 	JOIN sys.master_files mf ON db.database_id = mf.database_id


### PR DESCRIPTION
# Description
Previous .sql script for sizing would create an arithmetic overflow error on very large databases

## How Has This Been Tested?
Tested at customer with >10TB databases