### PR TITLE
Multi DC AG Failover

### DIFF
--- a/MSSQL/multi-dc-ag-failover.ps1
+++ b/MSSQL/multi-dc-ag-failover.ps1
@@ -14,23 +14,16 @@
 #>
 
 param(#Availability Group Name
-      [Parameter(ParameterSetName='Core')]
       [string]$agname,
 
       #Primary Rubrik connection info (cluster, user, password/token)
-      [Parameter(ParameterSetName='Core')]
       [string]$PrimaryRubrikCluster,
-      [Parameter(ParameterSetName='Core')]
       [pscredential]$PrimaryRubriCredential,
-      [Parameter(ParameterSetName='Core')]
       [string]$PrimaryRubrikToken,
 
       #Secondary Rubrik connection info (cluster, user, password/token)
-      [Parameter(ParameterSetName='Core')]
       [string]$SecondaryRubrikCluster,
-      [Parameter(ParameterSetName='Core')]
       [pscredential]$SecondaryRubriCredential,
-      [Parameter(ParameterSetName='Core')]
       [string]$SecondaryRubrikToken,
 
       #SLA Domain to be assigned

--- a/MSSQL/multi-dc-ag-failover.ps1
+++ b/MSSQL/multi-dc-ag-failover.ps1
@@ -4,7 +4,8 @@
 .DESCRIPTION
     This script is designed to enable or disable protection across an availability group
     to support cross data center failover. This script assumes that all the databases in the AG
-    are inheriting from the AG and no databases are directly assigned.
+    are inheriting from the AG and no databases are directly assigned. It also assumes that the
+    SLA domain name is the same for both sides of the AG.
 .EXAMPLE
     .\multi-dc-ag-failover -AGname YourAG -PrimaryRubrikCluster cluster1.yourdomain.com -PrimaryRubrikToken '0000-0000-0000-0000-0000' -SecondaryRubrikCluster cluster2.yourdomain.com -SecondaryRubrikToekn '0000-0000-0000-0000-0000'
         -SLAName 'YourSLA' -LogBackupFrequencyMin 15 -LogBackupRetentionDays 14
@@ -20,9 +21,7 @@ param(#Availability Group Name
       [Parameter(ParameterSetName='Core')]
       [string]$PrimaryRubrikCluster,
       [Parameter(ParameterSetName='Core')]
-      [string]$PrimaryRubrikUser,
-      [Parameter(ParameterSetName='Core')]
-      [securestring]$PrimaryRubrikPassword,
+      [pscredential]$PrimaryRubriCredential,
       [Parameter(ParameterSetName='Core')]
       [string]$PrimaryRubrikToken,
 
@@ -30,9 +29,7 @@ param(#Availability Group Name
       [Parameter(ParameterSetName='Core')]
       [string]$SecondaryRubrikCluster,
       [Parameter(ParameterSetName='Core')]
-      [string]$SecondaryRubrikUser,
-      [Parameter(ParameterSetName='Core')]
-      [securestring]$SecondaryRubrikPassword,
+      [pscredential]$SecondaryRubriCredential,
       [Parameter(ParameterSetName='Core')]
       [string]$SecondaryRubrikToken,
 
@@ -52,23 +49,40 @@ param(#Availability Group Name
       [Switch]$NewSnapshot
       )
 
-#connect to the cluster that will be the secondary
-if($SecondaryRubrikToken.Length -gt 0){
-    Connect-Rubrik -Server $SecondaryRubrikCluster -Token $SecondaryRubrikToken | Out-Null
-} else {
-    Connect-Rubrik -Server $SecondaryRubrikCluster -Username $SecondaryRubrikUser -Password @SecondaryRubrikPassword| Out-Null
+function New-RubrikConnection{
+    param($server,$cred,$token)
+    switch($true){
+        {$cred} {
+            $return = @{
+                Server = $server
+                Credential = $cred
+            }
+        }
+        {$token} {
+            $return = @{
+                Server = $server
+                Token = $token
+            }
+        }
+        default {
+            $return = @{
+                Server = $RubrikServer
+            }
+        }
+    }
+    return $return
 }
+#connect to the cluster that will be the secondary
+$connection = New-RubrikConnection -server $SecondaryRubrikCluster -cred $SecondaryRubriCredential -token $SecondaryRubrikToken
+Connect-Rubrik @connection
 #gather AG
 $secondaryag = Get-RubrikAvailabilityGroup -GroupName $agname
 Set-RubrikAvailabilityGroup -id $secondaryag.id -SLA UNPROTECTED -LogBackupFrequencyInSeconds 0 -LogRetentionHours 0 -Confirm:$false
 
-
 #connect to the cluster that will be the primary
-if($SecondaryRubrikToken.Length -gt 0){
-    Connect-Rubrik -Server $PrimaryRubrikCluster -Token $PrimaryRubrikToken | Out-Null
-} else {
-    Connect-Rubrik -Server $PrimaryRubrikCluster -Username $PrimaryRubrikUser -Password @PrimaryRubrikPassword| Out-Null
-}
+$connection = New-RubrikConnection -server $PrimaryRubrikCluster -cred $PrimaryRubriCredential -token $PrimaryRubrikToken
+Connect-Rubrik @connection
+
 #Enable protection on primary Rubrik cluster
 $primaryag = Get-RubrikAvailabilityGroup -GroupName $agname
 Set-RubrikAvailabilityGroup -id $primaryag.id -SLA $SLAName -LogBackupFrequencyInSeconds ($LogBackupFrequencyMin * 60) -LogRetentionHours ($LogBackupRetentionDays * 24) -Confirm:$false

--- a/MSSQL/multi-dc-ag-failover.ps1
+++ b/MSSQL/multi-dc-ag-failover.ps1
@@ -50,7 +50,7 @@ param(#Availability Group Name
       )
 
 function New-RubrikConnection{
-    param($server,$cred,$token)
+    param($server,[securestring]$cred,$token)
     switch($true){
         {$cred} {
             $return = @{
@@ -66,7 +66,7 @@ function New-RubrikConnection{
         }
         default {
             $return = @{
-                Server = $RubrikServer
+                Server = $server
             }
         }
     }

--- a/MSSQL/multi-dc-ag-failover.ps1
+++ b/MSSQL/multi-dc-ag-failover.ps1
@@ -1,0 +1,48 @@
+<#
+.SYNOPSIS
+    Script to enable or disable protection for a SQL Server Availability Group.
+.DESCRIPTION
+    This script is designed to enable or disable protection across an availability group
+    to support cross data center failover. 
+.EXAMPLE
+    #Enable Protection
+    PS C:\> .\multi-dc-ag-failover.ps1 -agname YourAvailabilityGroup -SLAName "SQL SLA" -LogBackupFrequencyMin 15 -LogBackupRetentionDay 14
+.EXAMPLE
+    #Disable Protection
+    PS C:\> .\multi-dc-ag-failover.ps1 -agname YourAvailabilityGroup -Disable
+.EXAMPLE
+    #Enable Protection and execute a snapshot
+    PS C:\> .\multi-dc-ag-failover.ps1 -agname YourAvailabilityGroup -SLAName "SQL SLA" -LogBackupFrequencyMin 15 -LogBackupRetentionDay 14 -NewSnapshot
+
+
+#>
+
+param([Parameter(ParameterSetName='Core')]
+      [string]$agname,
+      [Parameter(ParameterSetName='Enable')]
+      [Alias("Enable","SLA")]
+      [String]$SLAName,
+      [Parameter(ParameterSetName='Enable')]
+      [Alias("LogBackupFrequency")]
+      [int]$LogBackupFrequencyMin,
+      [Parameter(ParameterSetName='Enable')]
+      [Alias("LogBackupRetention")]
+      [int]$LogBackupRetentionDay,
+      [Parameter(ParameterSetName='Enable')]
+      [Switch]$NewSnapshot,
+      [Parameter(ParameterSetName='Disable')]
+      [Switch]$Disable
+      )
+
+$dbs = Get-RubrikDatabase -AvailabilityGroupName $agname
+
+if($SLAName.Length -gt 0) {
+      $dbs | Set-RubrikDatabase -SLA $SLAName -LogBackupFrequencyInSeconds ($LogBackupFrequencyMin * 60) -LogRetentionHours ($LogBackupRetentionDay * 24) -Confirm:$false
+
+      if($NewSnapshot){
+            $dbs | New-RubrikSnapshot -SLA $SLAName -Confirm:$false
+      }
+}
+if($Disable){
+      $dbs | Set-RubrikDatabase -SLA UNPROTECTED -LogBackupFrequencyInSeconds 0 -LogRetentionHours 0 -Confirm:$false
+}

--- a/MSSQL/multi-dc-ag-failover.ps1
+++ b/MSSQL/multi-dc-ag-failover.ps1
@@ -17,32 +17,43 @@
 
 #>
 
-param([Parameter(ParameterSetName='Core')]
+param(#Availability Group Name
+      [Parameter(ParameterSetName='Core')]
       [string]$agname,
+      #SLA Domain to be assigned
       [Parameter(ParameterSetName='Enable')]
       [Alias("Enable","SLA")]
       [String]$SLAName,
+      #Log backup frequecny in minutes
       [Parameter(ParameterSetName='Enable')]
       [Alias("LogBackupFrequency")]
       [int]$LogBackupFrequencyMin,
+      #Log backup retention in days
       [Parameter(ParameterSetName='Enable')]
       [Alias("LogBackupRetention")]
       [int]$LogBackupRetentionDay,
+      #Trigger new snapshot when enabling protection
       [Parameter(ParameterSetName='Enable')]
       [Switch]$NewSnapshot,
+      #disable protection
       [Parameter(ParameterSetName='Disable')]
       [Switch]$Disable
       )
 
+#gather databases to be altered based on AG name
 $dbs = Get-RubrikDatabase -AvailabilityGroupName $agname
 
+#If an SLA is declared, protection is being enabled. 
 if($SLAName.Length -gt 0) {
       $dbs | Set-RubrikDatabase -SLA $SLAName -LogBackupFrequencyInSeconds ($LogBackupFrequencyMin * 60) -LogRetentionHours ($LogBackupRetentionDay * 24) -Confirm:$false
 
+      #if NewSnapshot is flagged, execute a new on-demand snapshot once protection is re-enabled
       if($NewSnapshot){
             $dbs | New-RubrikSnapshot -SLA $SLAName -Confirm:$false
       }
 }
+
+#if the Disable switch is flagged, 
 if($Disable){
       $dbs | Set-RubrikDatabase -SLA UNPROTECTED -LogBackupFrequencyInSeconds 0 -LogRetentionHours 0 -Confirm:$false
 }

--- a/MSSQL/multi-dc-ag-failover.ps1
+++ b/MSSQL/multi-dc-ag-failover.ps1
@@ -6,14 +6,8 @@
     to support cross data center failover. This script assumes that all the databases in the AG
     are inheriting from the AG and no databases are directly assigned.
 .EXAMPLE
-    #Enable Protection
-    PS C:\> .\multi-dc-ag-failover.ps1 -agname YourAvailabilityGroup -SLAName "SQL SLA" -LogBackupFrequencyMin 15 -LogBackupRetentionDay 14
-.EXAMPLE
-    #Disable Protection
-    PS C:\> .\multi-dc-ag-failover.ps1 -agname YourAvailabilityGroup -Disable
-.EXAMPLE
-    #Enable Protection and execute a snapshot
-    PS C:\> .\multi-dc-ag-failover.ps1 -agname YourAvailabilityGroup -SLAName "SQL SLA" -LogBackupFrequencyMin 15 -LogBackupRetentionDay 14 -NewSnapshot
+    .\multi-dc-ag-failover -AGname YourAG -PrimaryRubrikCluster cluster1.yourdomain.com -PrimaryRubrikToken '0000-0000-0000-0000-0000' -SecondaryRubrikCluster cluster2.yourdomain.com -SecondaryRubrikToekn '0000-0000-0000-0000-0000'
+        -SLAName 'YourSLA' -LogBackupFrequencyMin 15 -LogBackupRetentionDays 14
 
 
 #>
@@ -52,7 +46,7 @@ param(#Availability Group Name
 
       #Log backup retention in days
       [Alias("LogBackupRetention")]
-      [int]$LogBackupRetentionDay,
+      [int]$LogBackupRetentionDays,
 
       #Trigger new snapshot when enabling protection
       [Switch]$NewSnapshot
@@ -77,7 +71,7 @@ if($SecondaryRubrikToken.Length -gt 0){
 }
 #Enable protection on primary Rubrik cluster
 $primaryag = Get-RubrikAvailabilityGroup -GroupName $agname
-Set-RubrikAvailabilityGroup -id $primaryag.id -SLA $SLAName -LogBackupFrequencyInSeconds ($LogBackupFrequencyMin * 60) -LogRetentionHours ($LogBackupRetentionDay * 24) -Confirm:$false
+Set-RubrikAvailabilityGroup -id $primaryag.id -SLA $SLAName -LogBackupFrequencyInSeconds ($LogBackupFrequencyMin * 60) -LogRetentionHours ($LogBackupRetentionDays * 24) -Confirm:$false
 
 #if NewSnapshot is flagged, execute a new on-demand snapshot once protection is re-enabled
 if($snapshot -eq $true){


### PR DESCRIPTION
# Description
This script can be used to automate reconfiguring Rubrik protection on an AG that spans two Rubrik clusters. The script will only modify protection at the Availability Group level, assuming that the databases all derive protection from the Availability Group. It also assumes that the SLA domain names are the same in both Rubrik clusters. To use the script, the customer will declare:

- The name of the Availability Group that is failing over.
- A Primary Rubrik cluster where protection will be enabled.
- A Secondary Rubrik cluster where protection will be disabled.
- Log backup frequency and retention for the Availability Group.
- Whether or not a new snapshot should be taken once the failover is complete.
- A credential or a token for each Rubrik cluster to authenticate the access.

## Motivation and Context
Written because many customers ask about this workflow.

## How Has This Been Tested?
Tested in Gaia.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](/CONTRIBUTING.md)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
