### PR TITLE
Update to New-FilesetSnapshot

### DIFF
--- a/NAS/New-FileSetSnapshot.ps1
+++ b/NAS/New-FileSetSnapshot.ps1
@@ -40,16 +40,16 @@
 #>
 param
 (
-    [Parameter(Mandatory=$false,HelpMessage="IP address or DNS name to Rubrik Cluster")]
+    [Parameter(Mandatory=$true,HelpMessage="IP address or DNS name to Rubrik Cluster")]
     [string]$RubrikServer,
 
-    [Parameter(Mandatory=$false,HelpMessage="Name of the Fileset created in Rubrik")]
+    [Parameter(Mandatory=$true,HelpMessage="Name of the Fileset created in Rubrik")]
     [string]$FileSetName,
 
-    [Parameter(Mandatory=$false,HelpMessage="Name of the server that will be backed up")]
+    [Parameter(Mandatory=$true,HelpMessage="Name of the server that will be backed up")]
     [string]$HostName,
 
-    [Parameter(Mandatory=$false,HelpMessage="Name of the SLA Domain")]
+    [Parameter(Mandatory=$true,HelpMessage="Name of the SLA Domain")]
     [string]$SLADomain,
 
     [Parameter(ParameterSetName = 'CredentialFile',HelpMessage="Path and filename of encrypted credential file")]
@@ -57,7 +57,7 @@ param
     [Parameter(ParameterSetName = 'Token')]
     [string]$Token
 )
-$Token = $Rubrik.token.emea1
+
 Import-Module Rubrik
 switch($true){
     {$RubrikCredentialFile} {$RubrikCredential = Import-CliXml -Path $RubrikCredentialFile

--- a/NAS/New-FileSetSnapshot.ps1
+++ b/NAS/New-FileSetSnapshot.ps1
@@ -1,9 +1,7 @@
 <#
     .SYNOPSIS
         Will create a new snapshot of a fileset on a server
-
     .DESCRIPTION
-        
     .PARAMETER Server
         IP address or DNS name to Rubrik Cluster
     .PARAMETER FileSetName
@@ -14,19 +12,14 @@
         Name of the SLA Domain
     .PARAMETER CredentialFile
         Path and filename of encrypted credential file
-
     .INPUTS
         None
-
     .OUTPUTS
         SUCCESS is a boolean value. $True if snapshot is successfull and $false if not. 
-
     .EXAMPLE
         .\New-FileSetSnapshot.ps1 -Server 172.21.8.51 -FileSetName 'Ola Hallengren SQL Backup Files' -HostName cl-sql2012n1.rangers.lab' -SLADomain 'SQL User Databases' -CredentialFile .\CredentialFile.Cred
-
     .LINK
         None
-
     .NOTES
         Name:       New FIle Set Snapshot
         Created:    5/2/2018
@@ -47,57 +40,55 @@
 #>
 param
 (
-    [Parameter(Mandatory=$true,HelpMessage="IP address or DNS name to Rubrik Cluster")]
-    [string]$Server,
+    [Parameter(Mandatory=$false,HelpMessage="IP address or DNS name to Rubrik Cluster")]
+    [string]$RubrikServer,
 
-    [Parameter(Mandatory=$true,HelpMessage="Name of the Fileset created in Rubrik")]
+    [Parameter(Mandatory=$false,HelpMessage="Name of the Fileset created in Rubrik")]
     [string]$FileSetName,
 
-    [Parameter(Mandatory=$true,HelpMessage="Name of the server that will be backed up")]
+    [Parameter(Mandatory=$false,HelpMessage="Name of the server that will be backed up")]
     [string]$HostName,
 
-    [Parameter(Mandatory=$true,HelpMessage="Name of the SLA Domain")]
+    [Parameter(Mandatory=$false,HelpMessage="Name of the SLA Domain")]
     [string]$SLADomain,
 
-    [Parameter(Mandatory=$true,HelpMessage="Path and filename of encrypted credential file")]
-    [string]$CredentialFile
+    [Parameter(ParameterSetName = 'CredentialFile',HelpMessage="Path and filename of encrypted credential file")]
+    [string]$RubrikCredentialFile,
+    [Parameter(ParameterSetName = 'Token')]
+    [string]$Token
 )
-
+$Token = $Rubrik.token.emea1
 Import-Module Rubrik
-$Credential = Import-CliXml -Path $CredentialFile
-Connect-Rubrik -Server $Server -Credential $Credential | Out-Null
+switch($true){
+    {$RubrikCredentialFile} {$RubrikCredential = Import-CliXml -Path $RubrikCredentialFile
+        $ConnectRubrik = @{
+            Server = $RubrikServer
+            Credential = $RubrikCredential
+        }
+    }
+    {$Token} {
+        $ConnectRubrik = @{
+            Server = $RubrikServer
+            Token = $Token
+        }
+    }
+    default {
+        $ConnectRubrik = @{
+            Server = $RubrikServer
+        }
+    }
+}
+Connect-Rubrik @ConnectRubrik
 
-$RubrikFileSet = Get-RubrikFileset -Name $FileSetName -HostName $HostName | Where-Object {$_.isRelic -eq 'False'}
+$RubrikFileSet = Get-RubrikFileset -Name $FileSetName -HostName $HostName | Where-Object {$_.isRelic -eq $false}
 
 $RubrikRequest = New-RubrikSnapshot -id $RubrikFileSet.id -SLA $SLADomain -Confirm:$false
 
-#Evaluate the request. Based on the status of the Async request, we will show the progress. We will exit if failure or success
-#If failure, we return false, but success we return true
-do
-{
-    $exit = $false
-    $success=$false
-    $Request = Get-RubrikRequest -id $RubrikRequest.id -Type 'fileset'
+$Request = Get-RubrikRequest -id $RubrikRequest.id -Type fileset -WaitForCompletion
 
-    switch -Wildcard ($Request.status) 
-    {
-        'QUE*' {Write-Progress -Activity "Backup up fileset $FileSetName on $HostName" -Status $Request.status -percentComplete (0)}
-        'RUN*' 
-        {
-            if ([string]::IsNullOrEmpty($Request.progress)){$PercentComplete = 0} else {$PercentComplete = $Request.progress}
-            Write-Progress -Activity "Backup up fileset $FileSetName on $HostName" -Status $Request.status -percentComplete $PercentComplete
-        }
-        'SUCCEED*' 
-        {
-            $exit = $true 
-            $success = $true
-        }
-        'FAIL*' 
-        {
-            $exit = $true 
-            $success = $false
-        }
-    }
-}until ($exit -eq $true)
+$Request
 
-$success
+#We now return back the full $RubrikRequest Information. This should be evaluated now for the status to determine if the script
+#is successfull or not. A Failed status is NOT a failed script. It is a failed fileset backup in Rubrik. If you see failure, you 
+#should then decide what is the next appropriate step in your workflow. 
+# $Request.status


### PR DESCRIPTION
# Description
Fixed issue with a check to see if the filset was a relic. Originally isRelic was a literal value, but now it is a boloean value. 

Add additional functionality for logging into Rubrik

Removed loop that checks the status of the submitted request and replaced with the functionality in the cmdlet of Get-RubrikRequest. This makes the script follow standards of other submitted scripts.
Please describe your pull request in detail.

## Related Issue

Original issue was reported to me by Christian Le Corre
