### PR TITLE
Add ability in CollectSQLProfile.ps1 to read instances from a file

### DIFF
--- a/DBSizingQueries/CollectSQLProfile.ps1
+++ b/DBSizingQueries/CollectSQLProfile.ps1
@@ -6,6 +6,7 @@ param(
     ,[Switch] $Anonymize
     ,[string] $SqlUser
     ,[string] $SqlPassword
+    ,[String] $InstanceCSVFile
 )
 BEGIN{
     if(Get-Module -ListAvailable SqlServer){Import-Module SqlServer}
@@ -14,6 +15,32 @@ BEGIN{
     $queries = Get-ChildItem $QueryPath -Filter "*.sql"
     $queries | ForEach-Object {$_ | Add-Member -MemberType NoteProperty -Name FileName -Value "$($_.Name.Replace('.sql',''))-$(Get-Date -Format 'yyyyMMddHHmm').csv"}
     $header = $true
+
+    # If specified, the host/instance entries in the csv file will be appended to the $SQLInstance array of String objects
+    #
+    # Format of CSV file:
+    #
+    # host,instance
+    # myhost,ZeSQLInstance
+    if (Test-Path $InstanceCSVFile -PathType leaf)
+    {
+        $instObjArray = Import-CSV -path $InstanceCSVFile
+
+        $instObjArray | ForEach-Object {
+            [String] $tmpInstance
+
+            if($_.instance -eq 'default')
+            {
+                $tmpInstance = $_.host
+            }
+            else
+            {
+                $tmpInstance = ("[0]\[1]" -f $_.host, $_.instance)
+            }
+
+            $SQLInstance += $tmpInstance
+        }
+    }
 }
 
 PROCESS
@@ -59,6 +86,7 @@ PROCESS
             $output = ""
         }
         $header = $false
-        }
     }
+}
+
 END{}


### PR DESCRIPTION
Fixes #163

# Description

Allows for supplying a csv file of Host/Instance pairs to avoid calling the CollectSQLProfile.ps1 in a loop.

## Related Issue

This project only accepts pull requests related to open issues.

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

https://github.com/rubrikinc/rubrik-scripts-for-powershell/issues/163

## Motivation and Context

If there are dozens, hundreds or more instances, the command line may exceed the maximum number of characters allowed.  Using a csv file avoids this limit.  

## How Has This Been Tested?

Tested using 80+ instances on numerous on prem machines.  


## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](/CONTRIBUTING.md)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
