### PR TITLE
Create Add_VM_to_CustomRole.ps1

### DIFF
--- a/MISC/Add_VM_to_CustomRole.ps1
+++ b/MISC/Add_VM_to_CustomRole.ps1
@@ -1,0 +1,94 @@
+<#
+.SYNOPSIS
+Add Virtual Machines into a custom role
+
+.DESCRIPTION
+Input the role you want to amend and the VM you want to add into the custom role. The script will retrieve the ID for the 
+for the role and use invoke-RubrikRESTcall to add the VM ID into the role.
+The privileges for the role can be be amended. this script adds the VM to 5 privileges, however you can change these to the specific privileges from the role you like to amend
+
+Change the following parameter:
+# Parameters
+$RubrikCluster="YOUR cluster DNS or IP Address"
+$roleName = "The role you like to amend"
+$vm2Add = "VM name to add"
+
+This script uses a credential file to gain access to the Rubrik Cluster
+# get credentials from saved encrypted xml file
+$Credxmlpath = "path to *.cred file"
+$CredXML = Import-Clixml $Credxmlpath
+
+to create a cred file use the following code
+$credential = Get-Credential
+Connect-Rubrik -Server $RubrikCluster -Credential $credential
+$credential | Export-Clixml -Path "path to *.cred file"
+
+.NOTES
+written by Harold Buter for community usage
+Twitter: @hbuter
+GitHub: hbuter-rubrik
+#>
+
+# Import Rubrik Module
+import-Module Rubrik
+
+# Parameters
+$RubrikCluster="[CLUSTER_DNS_NAME / IP ADDRESS]"
+$roleName = "[CUSTOM ROLE NAME]"
+$vm2Add = "[VM NAME TO ADD TO ROLE]"
+
+# get credentials from saved encrypted xml file
+$Credxmlpath = "[PATH TO CRED FILE] "
+$CredXML = Import-Clixml $Credxmlpath
+
+# connect to cluster
+Connect-Rubrik -Server $RubrikCluster -Credential $CredXML
+
+# Get Id for role
+$roleBody = Invoke-RubrikRESTCall -Endpoint 'role' -Method GET -Query @{'name'=$roleName}
+$roleID = $roleBody.data.roleId
+
+# Get information on the role itself
+$roleInfo = Invoke-RubrikRESTCall -api internal -Endpoint role/$roleID/authorization -Method GET | Select-Object -ExpandProperty authorizationSpecifications
+Write-Output $roleInfo
+
+# Get ID from VM to add to the role
+$VMID=(get-rubrikvm -name $vm2Add -PrimaryClusterID local|  Where-Object {$_.isRelic -ne 'TRUE'}).id
+Write-Output = $VMID
+
+
+# add the VM to the role
+$body = @{
+    "roleTemplate" = "EndUser";
+    "authorizationSpecifications" = @(
+        @{
+            "privilege" = "ManageProtection";
+            "resources" = @($VMID);
+        },
+        @{
+            "privilege" = "FileRestore";
+            "resources" = @($VMID);
+        },
+        @{
+            "privilege" = "LiveMount";
+            "resources" = @($VMID);
+        },
+        @{
+            "privilege" = "OnDemandSnapshot";
+            "resources" = @($VMID);
+        },
+        @{
+            "privilege" = "Export";
+            "resources" = @($VMID);
+        }
+    )
+};
+​
+Invoke-RubrikRESTCall -api internal -Endpoint role/$roleID/authorization -Method POST -Body $body
+
+
+
+
+
+
+


### PR DESCRIPTION
Input the role you want to amend and the VM you want to add into the custom role. The script will retrieve the ID for the 
for the role and use invoke-RubrikRESTcall to add the VM ID into the role.

# Description

Adding new file in Powershell MISC repository, this script will allow users to add Virtual Machine into a custom role

## Related Issue

Customer request to have such a script to automate adding VM into custom roles

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

_Please link to the issue here_

## Motivation and Context

No change, new script to automate adding VM into custom role

## How Has This Been Tested?

Tested in several Test environments
## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **[CONTRIBUTION](/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
