### PR TITLE
Update baseline scripts

### DIFF
--- a/MISC/Run-diskspdTests.ps1
+++ b/MISC/Run-diskspdTests.ps1
@@ -97,13 +97,13 @@ param (
     [Parameter(Mandatory=$false,Position=5)]
     $ReadBlockSize = "1M",
     
-    [Parameter(Mandatory=$false,Position=5)]
+    [Parameter(Mandatory=$false,Position=6)]
     $WriteBlockSize = "4M",
 
-    [Parameter(Mandatory=$false,Position=6)]
+    [Parameter(Mandatory=$false,Position=7)]
     $Threads = 16,
 
-    [Parameter(Mandatory=$false,Position=7)]
+    [Parameter(Mandatory=$false,Position=8)]
     $ThrottleLimit = 2
 )
 #region Variables

--- a/MISC/Run-diskspdTests.ps1
+++ b/MISC/Run-diskspdTests.ps1
@@ -158,14 +158,8 @@ function Start-DiskspdTest{
     foreach ($Volume in $Volumes){
         foreach ($IOType in $IOTypes){
             switch ($IOType){
-                "read" {
-                    $WriteTest = 0
-                    $arguments = "-c$($DataFileSize) -w$($WriteTest) -t$($Threads) -d$($TestDuration) -o$($IODepth) -b$($ReadBlockSize) -Z$($EntropySize) -W20 -Rxml -si -L $($Volume.Name)iotest.dat"
-                }
-                "write" {
-                    $WriteTest = 100
-                    $arguments = "-c$($DataFileSize) -w$($WriteTest) -t$($Threads) -d$($TestDuration) -o$($IODepth) -b$($WriteBlockSize) -Z$($EntropySize) -W20 -Rxml -si -L $($Volume.Name)iotest.dat"
-                }
+                "read" {$WriteTest = 0}
+                "write" {$WriteTest = 100}
             }
             foreach($IODepth in $IODepths){
                 #region timestamp output file
@@ -174,7 +168,16 @@ function Start-DiskspdTest{
                 #endregion
 
                 Write-Progress -Activity "Executing DiskSpd Tests..." -Status "Executing Test $TestNumber of $TestCount" -PercentComplete ( ($TestNumber / ($TestCount)) * 100 )
-                
+                switch ($IOType){
+                    "read" {
+                        $WriteTest = 0
+                        $arguments = "-c$($DataFileSize) -w$($WriteTest) -t$($Threads) -d$($TestDuration) -o$($IODepth) -b$($ReadBlockSize) -Z$($EntropySize) -W20 -Rxml -si -L $($Volume.Name)iotest.dat"
+                    }
+                    "write" {
+                        $WriteTest = 100
+                        $arguments = "-c$($DataFileSize) -w$($WriteTest) -t$($Threads) -d$($TestDuration) -o$($IODepth) -b$($WriteBlockSize) -Z$($EntropySize) -W20 -Rxml -si -L $($Volume.Name)iotest.dat"
+                    }
+                }
 
                 # Write-Output "diskspd.exe  $arguments" 
 

--- a/MISC/Run-iPerfTest.ps1
+++ b/MISC/Run-iPerfTest.ps1
@@ -68,7 +68,7 @@ foreach($RubrikNode in $RubrikNodes){
             Write-Host "Running .\iperf.exe -c $($RubrikNode.ipAddress) -i 5 -t 60 -w 1M"
             .\iperf.exe -c $RubrikNode.ipAddress -i 5 -t 60 -w 1M > "iperf_$($HostName)_to_$($RubrikNode.ipAddress)_1MB_1_Thread.txt"
 
-            Write-Host "Running .\iperf.exe -c $($RubrikNode.ipAddress) -i 5 -t 60 -w 1M -P 8"
+            Write-Host "Running .\iperf.exe -c $($RubrikNode.ipAddress) -i 5 -t 60 -w 1M -P 16"
             .\iperf.exe -c $RubrikNode.ipAddress -i 5 -t 60 -w 1M -P 8 > "iperf_$($HostName)_to_$($RubrikNode.ipAddress)_1MB_8_Threads.txt"
         }
         3 {
@@ -78,7 +78,7 @@ foreach($RubrikNode in $RubrikNodes){
             Write-Host "Running .\iperf3.exe -c $($RubrikNode.ipAddress) -i 5 -t 60 -w 1M"
             .\iperf3.exe -c $RubrikNode.ipAddress -i 5 -t 60 -w 1M > "iperf_$($HostName)_to_$($RubrikNode.ipAddress)_1MB_1_Thread.txt"
 
-            Write-Host "Running .\iperf3.exe -c $($RubrikNode.ipAddress) -i 5 -t 60 -w 1M -P 8 "
+            Write-Host "Running .\iperf3.exe -c $($RubrikNode.ipAddress) -i 5 -t 60 -w 1M -P 16 "
             .\iperf3.exe -c $RubrikNode.ipAddress -i 5 -t 60 -w 1M -P 8 > "iperf_$($HostName)_to_$($RubrikNode.ipAddress)_1MB_8_Threads.txt"
         }
     }


### PR DESCRIPTION
# Description

Updated Run-iPerfTest.ps1 to use 16 threads instead of 8. This is to more closely mimic how Rubrik transfers data. 

Updated Run-diskspdTests.ps1 to use different block sizes for read and write operations. This will more closely mimic a Rubrik workload
