### PR TITLE
create_vCenter_User.ps1 updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 Export-RubrikDatabasesJobFile - DN Test.json
 .idea
 .DS_Store
+vcenter_cred*.xml
+settings.json

--- a/VM/create_vCenter_User.ps1
+++ b/VM/create_vCenter_User.ps1
@@ -223,12 +223,13 @@ elseif (Test-Path $vCenterCredFile) {
 
 
 Write-Host "Creating a new role called $RubrikRole "`n -ForeGroundColor Cyan 
+New-VIRole -Name $RubrikRole -Privilege (Get-VIPrivilege -id $Rubrik_Privileges) | Out-Null
 
 #Get the Root Folder
 $rootFolder = Get-Folder -NoRecursion
 #Create the Permission
-Write-Host "Granting permissions on object $rootFolder to $Rubrik_User as role $Rubrik_Role with Propagation = $true"`n -ForeGroundColor Cyan
-New-VIPermission -Entity $rootFolder -Principal $Rubrik_User -Role $Rubrik_Role -Propagate:$true | Out-Null
+Write-Host "Granting permissions on object $rootFolder to $RubrikUser as role $RubrikRole with Propagation = $true"`n -ForeGroundColor Cyan
+New-VIPermission -Entity $rootFolder -Principal $RubrikUser -Role $RubrikRole -Propagate:$true | Out-Null
 
 #Disconnect from the vCenter Server
 Write-Host "Disconnecting from vCenter at $vCenter"`n -ForeGroundColor Cyan

--- a/VM/create_vCenter_User.ps1
+++ b/VM/create_vCenter_User.ps1
@@ -49,6 +49,8 @@ param (
  [string]$Domain
 )
 
+Import-Module VMware.VimAutomation.Core
+
 clear-host
 
 $usage = ".\create_vCenter_User.ps1 -vCenter vCenterFQDNorIP -Username RubrikServiceAccountName -Domain SAMAuthenticationDomain"

--- a/VM/create_vCenter_User.ps1
+++ b/VM/create_vCenter_User.ps1
@@ -48,7 +48,7 @@ param (
 
   [Parameter(Mandatory = $true)]
   # Hostname, FQDN or IP of the vCenter server.
- [string]$vCenter,
+  [string]$vCenter,
 
   [Parameter(Mandatory = $false)]
   # vCenter user with with admin privileges to create the Role and assign that role.
@@ -60,7 +60,7 @@ param (
 
   [Parameter(Mandatory = $true)]
   # Rubrik Service Account in vSphere to assign Rubrik privileges to.
- [string]$Username,
+  [string]$Username,
 
   [Parameter(Mandatory = $true)]
   # Domain of Rubrik Service Account in vSphere to assign Rubrik privileges to. 
@@ -220,7 +220,6 @@ elseif (Test-Path $vCenterCredFile) {
 
   Connect-VIServer -Server $vCenter -Credential $credential -Force | Out-Null
 }
-
 
 Write-Host "Creating a new role called $RubrikRole "`n -ForeGroundColor Cyan 
 New-VIRole -Name $RubrikRole -Privilege (Get-VIPrivilege -id $Rubrik_Privileges) | Out-Null

--- a/VM/create_vCenter_User.ps1
+++ b/VM/create_vCenter_User.ps1
@@ -49,6 +49,15 @@ param (
   [Parameter(Mandatory = $true)]
   # Hostname, FQDN or IP of the vCenter server.
  [string]$vCenter,
+
+  [Parameter(Mandatory = $false)]
+  # vCenter user with with admin privileges to create the Role and assign that role.
+  [string]$vCenterAdminUser = $null,
+
+  [Parameter(Mandatory = $false)]
+  # Password for vCenter admin user.
+  [string]$vCenterAdminPassword = $null,
+
   [Parameter(Mandatory = $true)]
   # Rubrik Service Account in vSphere to assign Rubrik privileges to.
  [string]$Username,
@@ -69,6 +78,8 @@ param (
   [string]$vCenterType,
 
   [Parameter(Mandatory = $false)]
+  # vCenter credential file to use. Default is ./vcenter_cred.xml.
+  [string]$vCenterCredFile = './vcenter_cred.xml'
 )
 
 Import-Module VMware.VimAutomation.Core

--- a/VM/create_vCenter_User.ps1
+++ b/VM/create_vCenter_User.ps1
@@ -44,9 +44,19 @@ Create the restricted permissions in an AVS vCenter and prompt for the vCenter u
 #>
 
 param (
+  [CmdletBinding()]
+
+  [Parameter(Mandatory = $true)]
+  # Hostname, FQDN or IP of the vCenter server.
  [string]$vCenter,
+  [Parameter(Mandatory = $true)]
+  # Rubrik Service Account in vSphere to assign Rubrik privileges to.
  [string]$Username,
- [string]$Domain
+
+  [Parameter(Mandatory = $true)]
+  # Domain of Rubrik Service Account in vSphere to assign Rubrik privileges to. 
+  # The -Domain parameter format is expected to be SAM; do not use the FQDN of 
+  # your domain name (e.g., RUBRIK)
 )
 
 Import-Module VMware.VimAutomation.Core

--- a/VM/create_vCenter_User.ps1
+++ b/VM/create_vCenter_User.ps1
@@ -57,6 +57,12 @@ param (
   # Domain of Rubrik Service Account in vSphere to assign Rubrik privileges to. 
   # The -Domain parameter format is expected to be SAM; do not use the FQDN of 
   # your domain name (e.g., RUBRIK)
+  [string]$Domain,
+
+  [Parameter(Mandatory = $false)]
+  # Role name to create. Default: Rubrik_Backup_Service
+  [string]$RubrikRole = 'Rubrik_Backup_Service',
+
   [Parameter(Mandatory = $true)]
   #Select the type of vCenter to add privileges for.
   [ValidateSet('ONPREM', 'VMC', 'AVS', 'GCVE')]

--- a/VM/create_vCenter_User.ps1
+++ b/VM/create_vCenter_User.ps1
@@ -1,7 +1,49 @@
 #requires -modules VMware.VimAutomation.Core
 
-# Get Commandline Parameters - All are required
-param(
+# https://build.rubrik.com
+# https://github.com/rubrikinc/rubrik-scripts-for-powershell
+
+<#
+.SYNOPSIS
+Creates a new role in vSphere with the restricted privileges needed to run Rubrik CDM. Assigns role to 
+Rubrik Service Account at the root of Hosts and Clusters.
+
+.DESCRIPTION
+The create_vCenter_User.ps1 cmdlet will create a new role in a vCenter with the minimum privileges to 
+allow Rubrik CDM to perform data protection in vSphere. The new role will be assigned to a specified
+user in vCenter. Options are provided for creating roles in on-prem vCenters, VMware Cloud on AWS (VMC)
+vCenters, Azure VMware Cloud Solution (AVS) and  Google VMware Cloud Engine (GCVE).
+
+.NOTES
+Updated by Damani Norman for community usage
+GitHub: DamaniN
+
+You can use a vCenter credential file for authentication
+Default $vCenterCredFile = './vcenter_cred.xml'
+To create one: Get-Credential | Export-CliXml -Path ./vcenter_cred.xml
+
+.EXAMPLE
+create_vCenter_User.ps1 
+
+Create the restricted permissions and prompt for all of the variables.
+
+.EXAMPLE
+create_vCenter_User.ps1 -vCenter <vcenter_server> -vCenterAdminUser <vcenter_admin_user> -vCenterAdminPassword <vcenter_admin_password> -Username <username_for_rubrik_role> -Domain <domain_of_rubrik_role_username> -RubrikRole <role_name> -vCenterType ONPREM
+
+Create the restricted permissions in an On-Prem vCenter using a username and password specified on the command line.
+
+.EXAMPLE
+create_vCenter_User.ps1 -vCenter <vcenter_server> -vCenterCredFile <credential_file> -Username <username_for_rubrik_role> -Domain <domain_of_rubrik_role_username> -RubrikRole <role_name> -vCenterType VMC
+
+Create the restricted permissions in an VMC vCenter using a specific vCenter credential file.
+
+.EXAMPLE
+create_vCenter_User.ps1 -vCenter <vcenter_server> -Username <username_for_rubrik_role> -Domain <domain_of_rubrik_role_username> -RubrikRole <role_name> -vCenterType AVS
+
+Create the restricted permissions in an AVS vCenter and prompt for the vCenter username and password.
+#>
+
+param (
  [string]$vCenter,
  [string]$Username,
  [string]$Domain

--- a/VM/create_vCenter_User.ps1
+++ b/VM/create_vCenter_User.ps1
@@ -100,16 +100,16 @@ $Rubrik_AVS_Privileges = @(
   'Datastore.Browse'
   'Datastore.Config'
   'Datastore.FileManagement'
-  'Global.ManageCustomFields' # Added for newer versions of CDM
-  'Global.SetCustomField' #Added for newer versions of CDM
-  'InventoryService.Tagging.AttachTag' # Added for newer versions of CDM.
+  'Global.ManageCustomFields' # Added per Rubrik CDM 6.0 Documentation
+  'Global.SetCustomField' # Added per Rubrik CDM 6.0 Documentation
+  'InventoryService.Tagging.AttachTag' # Used by Rubrik to reapply tags when recovering virtual machines. (vSphere 6.7 or earlier only)
   'Network.Assign'
   'Resource.AssignVMToPool'
   'Resource.ColdMigrate'
   'Resource.HotMigrate'
-  'Resource.QueryVMotion' # Added for newer versions of CDM
+  'Resource.QueryVMotion' # Check for vMotion in flight before taking snapshot
   'Sessions.ValidateSession'
-  'StorageProfile.View'
+  'StorageProfile.View' # Added for CDP filter driver management
   'StorageViews.View'
   'System.Anonymous'
   'System.Read'
@@ -158,7 +158,7 @@ $Rubrik_AVS_Privileges = @(
 
 # These privileges are not allowed in AVS but are allowed in VMC and GCVE
 $Rubrik_VMC_GCVE_Privileges = $Rubrik_AVS_Privileges + @(
-  'StorageProfile.Update' # Added for newer versions of CDM. Not allowed in AVS at this time.
+  'StorageProfile.Update'  # Added for CDP filter driver management. Not allowed in AVS at this time.
   'VApp.Import' # Required for HotAdd proxies (VMC/GCVE/AVS only)
 )
 
@@ -170,10 +170,10 @@ $Rubrik_OnPrem_Privileges = $Rubrik_VMC_GCVE_Privileges + @(
   'Global.DisableMethods' # Added for AppFlows
   'Global.EnableMethods' # Added for AppFlows
   'Global.Licenses'
-  'Host.Config.Image'
-  'Host.Config.Maintenance'
-  'Host.Config.Patch'
-  'Host.Config.Storage'
+  'Host.Config.Image' # Added for CDP filter driver management
+  'Host.Config.Maintenance' # Added for CDP filter driver management
+  'Host.Config.Patch' # Added for CDP filter driver management
+  'Host.Config.Storage' # Added for Live Mount
   'Sessions.TerminateSession'
 )
 

--- a/VM/create_vCenter_User.ps1
+++ b/VM/create_vCenter_User.ps1
@@ -1,5 +1,4 @@
-# PowerCLI script to create Rubrik Role which includes required permissions and assign Rubrik Service Account and Role at the root of Hosts and Clusters
-# Usage Create_Rubrik_Role.ps1 -vCenter vCenterFQDNorIP -Username ServiceAccountName -Domain AuthenticationDomain
+#requires -modules VMware.VimAutomation.Core
 
 # Get Commandline Parameters - All are required
 param(

--- a/VM/create_vCenter_User.ps1
+++ b/VM/create_vCenter_User.ps1
@@ -57,6 +57,12 @@ param (
   # Domain of Rubrik Service Account in vSphere to assign Rubrik privileges to. 
   # The -Domain parameter format is expected to be SAM; do not use the FQDN of 
   # your domain name (e.g., RUBRIK)
+  [Parameter(Mandatory = $true)]
+  #Select the type of vCenter to add privileges for.
+  [ValidateSet('ONPREM', 'VMC', 'AVS', 'GCVE')]
+  [string]$vCenterType,
+
+  [Parameter(Mandatory = $false)]
 )
 
 Import-Module VMware.VimAutomation.Core


### PR DESCRIPTION
# Description

- Updated documentation. 
- Made the creation of the vSphere user optional
- Added support for using credentials file with vSphere
- Added support for using command line for vSphere
- Added privilege needed for tagging support in vSphere 7.0 as well as version check of vSphere. (part of #162)
- Added check for PowerCLI VMware module

## Related Issue

- Fixed #162
- Fixed #166
- Fixed #196

## Motivation and Context

Why is this change required? What problem does it solve?

See the description and linked issues. 

## How Has This Been Tested?

Created new roles in VMC, AVS, GCVE and on-prem vCenters. Also deleted associated roles to verify deletes were not impacted in VMware Cloud environments (known issues when roles are over privileged on creation)

## Screenshots (if appropriate):

None

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
